### PR TITLE
Fix kafkacat to version 5.0.0 image (#452)

### DIFF
--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - "*/*.kafka.sh"
 
   kafkacattest:
-    image: confluentinc/cp-kafkacat
+    image: confluentinc/cp-kafkacat:5.0.0
     environment:
        - BROKER_LIST
        - KAFKA_VERSION=${KAFKA_VERSION-2.1.0}


### PR DESCRIPTION
It appears the -e flag behaves differently on more recent (latest)
versions, so needs further investigation